### PR TITLE
[extra/flashplugin] Introduce 32-bit package

### DIFF
--- a/extra/flashplugin/PKGBUILD
+++ b/extra/flashplugin/PKGBUILD
@@ -1,0 +1,54 @@
+# $Id$
+# Maintainer: Evangelos Foutras <evangelos@foutrelis.com>
+# Contributor: Ionut Biru <ibiru@archlinux.org>
+# Contributor: Andrea Scarpino <andrea@archlinux.org>
+# Contributor: Jonathon Fernyhough <jonathon manjaro_dot_org>
+
+pkgname=(flashplugin pepper-flash)
+pkgver=28.0.0.126
+pkgrel=2
+pkgdesc="Adobe Flash Player"
+arch=('i686')
+url="https://get.adobe.com/flashplayer/"
+license=('custom' 'LGPL')
+options=('!strip')
+source=(flash_player_npapi_linux_$pkgver.i386.tar.gz::https://fpdownload.adobe.com/get/flashplayer/pdc/$pkgver/flash_player_npapi_linux.i386.tar.gz
+        flash_player_ppapi_linux_$pkgver.i386.tar.gz::https://fpdownload.adobe.com/get/flashplayer/pdc/$pkgver/flash_player_ppapi_linux.i386.tar.gz)
+noextract=(${source[@]%::*})
+sha256sums=('9ef7d79adce8bdf5529d26a4e1ded20d754dea628da60c455500e3532396de4f'
+            'b71c532d0fd530ece0fa50c9ac2a0f891e3be11fd7090af59726e38ebd79a004')
+
+prepare() {
+  local _dir
+  for f in *.tar.gz; do
+    _dir=$(grep -Eo '([np]papi)' <<< $f)
+    mkdir -p $_dir
+    tar xfC $f $_dir
+  done
+}
+
+package_flashplugin() {
+  pkgdesc+=" NPAPI"
+  depends=('libxt' 'gtk2' 'nss' 'curl' 'hicolor-icon-theme')
+  optdepends=('libvdpau: GPU acceleration on Nvidia cards')
+
+  cd npapi
+  install -Dm644 libflashplayer.so "$pkgdir/usr/lib/mozilla/plugins/libflashplayer.so"
+  install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" license.pdf LGPL/notice.txt
+
+  install -D -t "$pkgdir/usr/bin" usr/bin/flash-player-properties
+  cp -a usr/share/{applications,icons} "$pkgdir/usr/share/"
+
+}
+
+package_pepper-flash() {
+  pkgdesc+=" PPAPI"
+  depends=('gcc-libs')
+  optdepends=('flashplugin: settings utility')
+
+  cd ppapi
+  install -Dm644 -t "$pkgdir/usr/lib/PepperFlash" manifest.json libpepflashplayer.so
+  install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname" license.pdf LGPL/notice.txt
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
The Arch [PKGBUILD](https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/flashplugin) dropped [i686 support](https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/flashplugin&id=4414b789a46d37e53330acce7f9ae73dce7698e1) and the arch32 package has slurped the x86_64-only content. This PKGBUILD sets up 32-bit support for `flashplugin` (for as long as Adobe support it, at least...).