### PR TITLE
Keyring updates

### DIFF
--- a/core/archlinux32-keyring-transition/PKGBUILD
+++ b/core/archlinux32-keyring-transition/PKGBUILD
@@ -15,6 +15,6 @@ sha512sums=('e1bb190ea3895ecff789eeb25b35758704d2528f46cf2861c7cd89250eca9396e22
 validpgpkeys=('5FDCA472AB93292BC678FD59255A76DB9A12601A') # Erich Eckner (just to sign arch packages) <arch@eckner.net>
 
 package() {
-    cd "${srcdir}/${_pkgname}-"* # ${pkgver}"
+    cd "${srcdir}/${_pkgname}-v${pkgver}"
     make PREFIX=/usr DESTDIR=${pkgdir} install
 }

--- a/core/archlinux32-keyring-transition/PKGBUILD
+++ b/core/archlinux32-keyring-transition/PKGBUILD
@@ -5,10 +5,10 @@ pkgver=20170628
 pkgrel=1
 pkgdesc='Arch Linux 32 PGP keyring - transition package'
 arch=('any')
-url='http://archlinux32.org'
+url='https://archlinux32.org'
 license=('GPL')
-install="${pkgname}.install"
 provides=('archlinux32-keyring')
+install="${pkgname}.install"
 source=("https://github.com/archlinux32/$_pkgname/archive/v$pkgver.tar.gz")
 sha512sums=('3c088e02bda95dfa4e72a3afd6e934f8920fb5befaea1080d40cc5594ff77c8bff0f994028b7d371411c35cf4959cc25fc72e07c4d94694872f09be4f3e0d64a')
 

--- a/core/archlinux32-keyring-transition/PKGBUILD
+++ b/core/archlinux32-keyring-transition/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Erich Eckner <deep42thought@archlinux32.org>
 pkgname=archlinux32-keyring-transition
 _pkgname=${pkgname%-*}
-pkgver=20170628
+pkgver=20180411
 pkgrel=1
 pkgdesc='Arch Linux 32 PGP keyring - transition package'
 arch=('any')
@@ -9,8 +9,10 @@ url='https://archlinux32.org'
 license=('GPL')
 provides=('archlinux32-keyring')
 install="${pkgname}.install"
-source=("https://github.com/archlinux32/$_pkgname/archive/v$pkgver.tar.gz")
-sha512sums=('3c088e02bda95dfa4e72a3afd6e934f8920fb5befaea1080d40cc5594ff77c8bff0f994028b7d371411c35cf4959cc25fc72e07c4d94694872f09be4f3e0d64a')
+source=("https://github.com/archlinux32/${_pkgname}/releases/download/v${pkgver}/${_pkgname}-v${pkgver}.tar.xz"{,.sig})
+sha512sums=('e1bb190ea3895ecff789eeb25b35758704d2528f46cf2861c7cd89250eca9396e22d9be2bf42dd3fda2dba0c858216eca51d93d7a5ce7e84691a3965fa9aa63e'
+            'SKIP')
+validpgpkeys=('5FDCA472AB93292BC678FD59255A76DB9A12601A') # Erich Eckner (just to sign arch packages) <arch@eckner.net>
 
 package() {
     cd "${srcdir}/${_pkgname}-"* # ${pkgver}"

--- a/core/archlinux32-keyring/PKGBUILD
+++ b/core/archlinux32-keyring/PKGBUILD
@@ -4,11 +4,11 @@ pkgver=20180411
 pkgrel=1
 pkgdesc='Arch Linux 32 PGP keyring'
 arch=('any')
-url='http://archlinux32.org'
+url='https://archlinux32.org'
 license=('GPL')
-install="${pkgname}.install"
 conflicts=('archlinux32-keyring-transition')
 replaces=('archlinux32-keyring-transition')
+install="${pkgname}.install"
 source=("https://github.com/archlinux32/$pkgname/archive/v$pkgver.tar.gz")
 sha512sums=('ed178d1d3bf8f968d16dadd037673f3dd46996001d6b62aca84ef7ba0197f201dc11db9b545b90f498537b12ce3cef31a72d1fc79f286cbd82408be5f64759b7')
 

--- a/core/archlinux32-keyring/PKGBUILD
+++ b/core/archlinux32-keyring/PKGBUILD
@@ -9,8 +9,10 @@ license=('GPL')
 conflicts=('archlinux32-keyring-transition')
 replaces=('archlinux32-keyring-transition')
 install="${pkgname}.install"
-source=("https://github.com/archlinux32/$pkgname/archive/v$pkgver.tar.gz")
-sha512sums=('ed178d1d3bf8f968d16dadd037673f3dd46996001d6b62aca84ef7ba0197f201dc11db9b545b90f498537b12ce3cef31a72d1fc79f286cbd82408be5f64759b7')
+source=("https://github.com/archlinux32/${pkgname}/releases/download/v${pkgver}/${pkgname}-v${pkgver}.tar.xz"{,.sig})
+sha512sums=('e1bb190ea3895ecff789eeb25b35758704d2528f46cf2861c7cd89250eca9396e22d9be2bf42dd3fda2dba0c858216eca51d93d7a5ce7e84691a3965fa9aa63e'
+            'SKIP')
+validpgpkeys=('5FDCA472AB93292BC678FD59255A76DB9A12601A') # Erich Eckner (just to sign arch packages) <arch@eckner.net>
 
 package() {
     cd "${srcdir}/${pkgname}-"* # ${pkgver}"

--- a/core/archlinux32-keyring/PKGBUILD
+++ b/core/archlinux32-keyring/PKGBUILD
@@ -15,6 +15,6 @@ sha512sums=('e1bb190ea3895ecff789eeb25b35758704d2528f46cf2861c7cd89250eca9396e22
 validpgpkeys=('5FDCA472AB93292BC678FD59255A76DB9A12601A') # Erich Eckner (just to sign arch packages) <arch@eckner.net>
 
 package() {
-    cd "${srcdir}/${pkgname}-"* # ${pkgver}"
+    cd "${srcdir}/${pkgname}-v${pkgver}"
     make PREFIX=/usr DESTDIR=${pkgdir} install
 }


### PR DESCRIPTION
Since github apparently doesn't support real fileypes ("Try again with a GIF, JPEG, JPG, PNG, DOCX, GZ, LOG, PDF, PPTX, TXT, XLSX or ZIP") I've uploaded my transition package build to pkgbuild.com

(Why does it support gz, but not xz? Why does it even care what you name it?)

Verified from the old transition package signed by brtln, which verified @tyzoid's key used to sign the current keyring package, which contain's @deep-42-thought's key used to sign the keyring release.

https://pkgbuild.com/~eschwartz/archlinux32-keyring-transition-20180411-1-any.pkg.tar.xz
https://pkgbuild.com/~eschwartz/archlinux32-keyring-transition-20180411-1-any.pkg.tar.xz.sig