### PR TITLE
[chromium] Fix bundled FFMPEG compilation

### DIFF
--- a/extra/chromium/PKGBUILD
+++ b/extra/chromium/PKGBUILD
@@ -1,3 +1,1 @@
-depends+=('ffmpeg')
-
-_system_libs[ffmpeg]=ffmpeg
+CFLAGS+=' -mno-stackrealign'


### PR DESCRIPTION
This fixes the issue

```
 ../../third_party/ffmpeg/libavcodec/x86/cabac.h:193:9: error: inline assembly requires more registers than available
```
building the bundled FFMPEG libraries and in turn gets Chromium building again.

https://bbs.archlinux32.org/viewtopic.php?pid=4430#p4430